### PR TITLE
system-config-date

### DIFF
--- a/system-config-kickstart.spec
+++ b/system-config-kickstart.spec
@@ -16,9 +16,9 @@ Source0: %{name}-%{version}.tar.gz
 Obsoletes: ksconfig, redhat-config-kickstart, mkkickstart
 BuildRequires: desktop-file-utils, intltool, gettext
 BuildRequires: transifex-client
-Requires: pygtk2 >= 1.99.11, pygtk2-libglade, python >= 2.3.3
+Requires: pygtk2 >= 1.99.11, pygtk2-libglade, python2 >= 2.3.3
 Requires: system-config-language, system-config-date
-Requires: python-kickstart, yum, hicolor-icon-theme
+Requires: python2-kickstart, yum, hicolor-icon-theme
 Requires: system-config-keyboard >= 1.3.1
 Requires(post): gtk2 >= 2.6
 Requires(postun): gtk2 >= 2.6

--- a/system-config-kickstart.spec
+++ b/system-config-kickstart.spec
@@ -17,7 +17,8 @@ Obsoletes: ksconfig, redhat-config-kickstart, mkkickstart
 BuildRequires: desktop-file-utils, intltool, gettext
 BuildRequires: transifex-client
 Requires: pygtk2 >= 1.99.11, pygtk2-libglade, python2 >= 2.3.3
-Requires: system-config-language, system-config-date
+Requires: system-config-language
+Requires: python2-pytz
 Requires: python2-kickstart, yum, hicolor-icon-theme
 Requires: system-config-keyboard >= 1.3.1
 Requires(post): gtk2 >= 2.6


### PR DESCRIPTION
Apparently the system-config-date dependency is causing some consternation in Fedora-land. Here's pretty much the minimum necessary to keep s-c-k limping along.