### PR TITLE
Fixes failure if install-method URL is unset while loading kickstart file

### DIFF
--- a/src/install.py
+++ b/src/install.py
@@ -251,10 +251,11 @@ class install:
                 self.nfsdir_entry.set_text(self.ks.method.dir)
 
         elif self.ks.method.method == "url":
-            tokens = string.split(self.ks.method.url, "://")
+            if self.ks.method.url is not None:
+                tokens = string.split(self.ks.method.url, "://")
 
-            protocol = tokens[0]
-            data = tokens[1]
+                protocol = tokens[0]
+                data = tokens[1]
 
             if protocol == "ftp":
                 self.ftp_radiobutton.set_active(True)


### PR DESCRIPTION
If `self.ks.method.url` is unset, but (for some reason) `self.ks.method.method` is forced to be `url` then following traceback is thrown while parsing kickstart files.

```
  File "/usr/share/system-config-kickstart/install.py", line 254, in applyKickstart
    tokens = string.split(self.ks.method.url, "://")
  File "/usr/lib64/python2.7/string.py", line 294, in split
    return s.split(sep, maxsplit)
AttributeError: 'NoneType' object has no attribute 'split'
```

Better solution would be to diagnose why `self.ks.method.method == "url"` in the first place, even if it's not defined by kickstart file, and resolve that, but this patch ensures, no matter what the source of the problem is, it'll not cause issues in this particular case by safeguarding it within a type-check conditional.

Signed-off-by: Soumya Deb <debloper@gmail.com>