### PR TITLE
Use SHA512 for storing hashed passwords

### DIFF
--- a/src/basic.py
+++ b/src/basic.py
@@ -170,7 +170,7 @@ class basic:
 
         if pure != "":
             if self.encrypt_root_pw_checkbutton.get_active() == True:
-                salt = "$1$"
+                salt = "$6$"
                 saltLen = 8
 
                 if not pure.startswith(salt):

--- a/src/bootloader.py
+++ b/src/bootloader.py
@@ -135,7 +135,7 @@ class GrubBootloader(AbstractBootloader):
                 if len(gp) > 0:
                     if gp == cp:
                         if self.grub_password_encrypt_checkbutton.get_active():
-                            salt = "$1$"
+                            salt = "$6$"
                             saltLen = 8
                             for i in range(saltLen):
                                 salt = salt + random.choice (string.letters + string.digits + './')


### PR DESCRIPTION
The root password and grub password were encrypted using
an (insecure) MD5 hash. The resulting kickstart file would
build virtual machines that store the (insecure) MD5
hashed password for root in /etc/shadow.

Since current operating systems using glibc 2.7 (or later)
default to SHA512 hashes for /etc/shadow and support SHA512
for grub, and Python 2.7's crypt function will generate a
SHA512 has for any salt starting with '$6$', this patch
changes the algorithm to SHA512 for storing hashed passwords.